### PR TITLE
Volume according to the API

### DIFF
--- a/docs/02_API/02_WebSocket_APIs.md
+++ b/docs/02_API/02_WebSocket_APIs.md
@@ -405,6 +405,7 @@ Input:
 ```json
    {
     "name":"my playlist",
+    "service":"mpd",
     "uri":"USB/..."
    }
 ```

--- a/docs/02_API/02_WebSocket_APIs.md
+++ b/docs/02_API/02_WebSocket_APIs.md
@@ -35,7 +35,7 @@ A good policy for sending data on emits is to configure them as objects: they're
 So our message can be:
 
 ```js
-io.emit('setVolume',{volume:30,mute=false}
+io.emit('addToPlaylist', {"name": "Music", "service": "mpd", "uri": "music-library/..."});
 ```
 ## Events Documentation
 

--- a/docs/02_API/02_WebSocket_APIs.md
+++ b/docs/02_API/02_WebSocket_APIs.md
@@ -115,7 +115,7 @@ Data:
 * *-*
 
 **Example**
-```
+```js
 io.emit('volume', 90);
 io.emit('volume', '+');
 ```
@@ -124,7 +124,7 @@ io.emit('volume', '+');
 Message: *mute*
 
 **Example**
-```
+```js
 io.emit('mute', '');
 ```
 
@@ -132,7 +132,7 @@ io.emit('mute', '');
 Message: *unmute*
 
 **Example**
-```
+```js
 io.emit('unmute', '');
 ```
 

--- a/docs/02_API/02_WebSocket_APIs.md
+++ b/docs/02_API/02_WebSocket_APIs.md
@@ -109,10 +109,10 @@ Message: *volume*
 Data:
 
 * numeric value between 0 and 100
-* 'mute'
-* 'umute'
-* '+'
-* '-'
+* *mute*
+* *umute*
+* *+*
+* *-*
 
 **Example**
 ```

--- a/docs/02_API/02_WebSocket_APIs.md
+++ b/docs/02_API/02_WebSocket_APIs.md
@@ -101,16 +101,40 @@ search {value:'query'}
 
 Where query is my search query. (note that for using live search, DO NOT send queries with less than 3 characters, they will dramatically slow search operations).
 
-### Set the Volume
+### Volume
+Set to percentage, raise or lower, mute or unmute.
 
+Message: *volume*
+
+Data:
+
+* numeric value between 0 and 100
+* 'mute'
+* 'umute'
+* '+'
+* '-'
+
+**Example**
 ```
-volume {vol:90,mute:false}
+socket.emit('volume', 90);
+socket.emit('volume', '+');
 ```
 
-Where `vol` is a numeric (0-100) volume level, and mute is a boolean
+### Mute
+Message: *mute*
 
+**Example**
+```
+socket.emit('mute', '');
+```
 
-When Volume is already muted, sending another "mute" emit will result in Volume being unmuted
+### Unmute
+Message: *unmute*
+
+**Example**
+```
+socket.emit('unmute', '');
+```
 
 ### Multiroom
 ```

--- a/docs/02_API/02_WebSocket_APIs.md
+++ b/docs/02_API/02_WebSocket_APIs.md
@@ -116,8 +116,8 @@ Data:
 
 **Example**
 ```
-socket.emit('volume', 90);
-socket.emit('volume', '+');
+io.emit('volume', 90);
+io.emit('volume', '+');
 ```
 
 ### Mute
@@ -125,7 +125,7 @@ Message: *mute*
 
 **Example**
 ```
-socket.emit('mute', '');
+io.emit('mute', '');
 ```
 
 ### Unmute
@@ -133,7 +133,7 @@ Message: *unmute*
 
 **Example**
 ```
-socket.emit('unmute', '');
+io.emit('unmute', '');
 ```
 
 ### Multiroom


### PR DESCRIPTION
The volume API seems to have changed and the old examples did not work.

Also, even though mostly the same code is repeated, I find it more clear to give examples like:

**Example**
```js
io.emit('unmute', '');
```