### PR TITLE
Fix - how to allow access from outside

### DIFF
--- a/docs/07_Good_to_Knows/04_Connection_Outside_LAN.md
+++ b/docs/07_Good_to_Knows/04_Connection_Outside_LAN.md
@@ -3,10 +3,17 @@ to the external IP rather than the LAN's IP.
 
  #### Tell the UI to bind to new IP
 
- If you want to achieve this, hardcode your public IP in [https://github.com/volumio/Volumio2/blob/master/http/restapi.js](https://github.com/volumio/Volumio2/blob/master/http/restapi.js line 49
+ If you want to achieve this, hardcode your public IP in [https://github.com/volumio/Volumio2/blob/master/http/restapi.js](https://github.com/volumio/Volumio2/blob/master/http/restapi.js line 7
+
+Change:
 
 ```
-res.json({ host: 'http://'+self.host});
+var primaryhost = undefined;
+```
+To:
+
+```
+var primaryhost = 'http://[YOUR_PUBLIC_IP]:3000';
 ```
 
 your public ip instead of self.host


### PR DESCRIPTION
Current description was misleading. Actual changes should be in [line 7](https://github.com/volumio/Volumio2/blob/master/http/restapi.js#L7)
Even after changing [line 48](https://github.com/volumio/Volumio2/blob/master/http/restapi.js#L48) ([line 49 is an `else`](https://github.com/volumio/Volumio2/blob/master/http/restapi.js#L49)), the configuration is ignored due to the check [`if (primaryhost != undefined ) {` on line 47](https://github.com/volumio/Volumio2/blob/master/http/restapi.js#L47).