### PR TITLE
Gulp getting started address moved.

### DIFF
--- a/docs/01_Development_How_To/04_Set_up_development_environment_for_UI.md
+++ b/docs/01_Development_How_To/04_Set_up_development_environment_for_UI.md
@@ -8,7 +8,7 @@ To set up a development environment on your PC\MAC do:
 ### Install dependencies (only first time)
 * Download and install [Node.js](https://nodejs.org/it/download/)
 * Download and install [Bower](https://bower.io/#install-bower)
-* Download and install [Gulp](https://github.com/gulpjs/gulp/blob/master/docs/getting-started.md)
+* Download and install [Gulp](https://github.com/gulpjs/gulp/blob/master/docs/getting-started/1-quick-start.md)
 
 ### Prepare Volumio2 UI Development folder
 


### PR DESCRIPTION
Changed link to point to the Quick Start guide.