### PR TITLE
Specify Node.js 6.x in install instructions

### DIFF
--- a/docs/01_Development_How_To/04_Set_up_development_environment_for_UI.md
+++ b/docs/01_Development_How_To/04_Set_up_development_environment_for_UI.md
@@ -7,7 +7,7 @@ To set up a development environment on your PC\MAC do:
 
 ### Install dependencies (only first time)
 * Download and install [Node.js](https://nodejs.org/it/download/)
-** Volumio2-UI currently requires Node.js 6.*. [6.9.5](https://nodejs.org/dist/v6.9.5/)
+** Volumio2-UI currently requires '''Node.js 6.*'''. [6.9.5](https://nodejs.org/dist/v6.9.5/)
 * Download and install [Bower](https://bower.io/#install-bower)
 * Download and install [Gulp](https://github.com/gulpjs/gulp/blob/master/docs/getting-started/1-quick-start.md)
 

--- a/docs/01_Development_How_To/04_Set_up_development_environment_for_UI.md
+++ b/docs/01_Development_How_To/04_Set_up_development_environment_for_UI.md
@@ -7,6 +7,7 @@ To set up a development environment on your PC\MAC do:
 
 ### Install dependencies (only first time)
 * Download and install [Node.js](https://nodejs.org/it/download/)
+** Volumio2-UI currently requires Node.js 6.*. [6.9.5](https://nodejs.org/dist/v6.9.5/)
 * Download and install [Bower](https://bower.io/#install-bower)
 * Download and install [Gulp](https://github.com/gulpjs/gulp/blob/master/docs/getting-started/1-quick-start.md)
 


### PR DESCRIPTION
To force compatibility, devs should install Node.js v 6.x (6.9.5 latest).