### PR TITLE
Fix "index.fs" typo

### DIFF
--- a/docs/03_Plugin_System/03_Index.js.md
+++ b/docs/03_Plugin_System/03_Index.js.md
@@ -1,4 +1,4 @@
-## The index.fs file of a plugin
+## The index.js file of a plugin
 
 ### Index.js aka the plugin's core
 


### PR DESCRIPTION
Plugin Docs had a confusing header...fixed.