### PR TITLE
Correction/addition regarding userconfig.txt

### DIFF
--- a/docs/00_User_Manual/09_Other_Customizations.md
+++ b/docs/00_User_Manual/09_Other_Customizations.md
@@ -24,4 +24,22 @@ On a Raspberry Pi system configuration parameters are set in a file called /boot
 
 This file gets overwritten on each Volumio update so user made changes in /boot/config.txt are not preserved. To make them permanent custom settings need to be added to /boot/userconfig.txt instead.
 
-**Note:** A gpu_mem setting in /boot/userconfig.txt only takes effect if the gpu_mem setting in /boot/config.txt has been removed/commented. The same goes for gpu_mem_256, gpu_mem_512 and gpu_mem_1024.
+**Note:** The following options do not work when placed in /boot/userconfig.txt:
+```
+gpu_mem
+gpu_mem_256
+gpu_mem_512
+gpu_mem_1024
+total_mem
+require_total_mem
+startx
+start_x
+start_debug
+boot_partition
+legacy_mapping
+bootcode_delay
+force_pvt
+uart_2ndstage
+start_file
+fixup_file
+```


### PR DESCRIPTION
According to this [list](https://github.com/raspberrypi/firmware/issues/1332#issuecomment-584166999) some boot options do not work when placed in an file referenced by the include option in /boot/config.txt. They are processed at an (too) early stage of the boot process when the included file does not get parsed.